### PR TITLE
Preserve title and className if they are set by `createControlMarkup`

### DIFF
--- a/lib/OpenLayers/Control/Panel.js
+++ b/lib/OpenLayers/Control/Panel.js
@@ -249,8 +249,10 @@ OpenLayers.Control.Panel = OpenLayers.Class(OpenLayers.Control, {
         for (var i=0, len=controls.length; i<len; i++) {
             var control = controls[i],
                 element = this.createControlMarkup(control);
-            element.className = control.displayClass + "ItemInactive olButton";
-            if (control.title != "") {
+            OpenLayers.Element.addClass(element, 
+                                        control.displayClass + "ItemInactive");
+            OpenLayers.Element.addClass(element, "olButton");
+            if (control.title != ""  && !element.title) {
                 element.title = control.title;
             }
             control.panel_div = element;


### PR DESCRIPTION
... as "ahocevar" suggested.
